### PR TITLE
docs: improve README and project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,53 @@
-# CalculiX execution environment
+# Docker Calculix
 
-## What is CalculiX
+This project provides Docker Compose configuration to run CalculiX in a containerized environment.
 
-CalculiX is an open source program of the Finite Element Method.
+CalculiX is an open-source program for Finite Element Analysis (FEA) of structural problems. This project builds and runs CalculiX 2.20 inside an Ubuntu 22.04 container, so you can use it without installing the toolchain on your host machine.
 
+## 📦 Requirements
+
+- [Docker](https://www.docker.com/)
+- Docker Compose v2 (the `docker compose` command)
+
+## ⚙️ Setup
+
+### Create secret.txt
+
+Create a text file named `secret.txt` in the project root containing the password
+for the `ubuntu` user inside the container. The entire file content is used as the
+password, so it should contain only the password itself:
+
+```text
+YourPassword!
+```
+
+> **Note:** `secret.txt` contains a credential and should not be committed to version control.
+
+## 🚀 Usage
+
+### Build and Start Docker Container
+
+Run the following script to build the Docker image `docker-calculix-ubuntu` and start the container `ubuntu-calculix`:
+
+```bash
+./run-compose.sh
+```
+
+### Access the Container
+
+Run the following script to enter the container:
+
+```bash
+./docker-in.sh
+```
+
+## 📚 Reference
+
+- [CalculiX: A Three-Dimensional Structural Finite Element Program](https://www.dhondt.de)
+- [Docker](https://www.docker.com/)
+
+## 📄 License
+
+This project is licensed under GPL 2.0.
+
+Please see [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Summary

Improve the project documentation to help new users understand and use this tool.

- Add a clear project description explaining what CalculiX is (open-source FEA program, built as CalculiX 2.20 on Ubuntu 22.04)
- Restructure into Requirements / Setup / Usage / Reference / License sections
- Fix `secret.txt` instructions: the whole file content is used as the password, so document the raw value instead of a `key=value` format
- Note that `secret.txt` is a credential and should not be committed
- Fix typo in the CalculiX reference link ("Three-Dimensional")

The repository "About" description has also been set in the GitHub settings.

## Related Issues

Closes #2

## How Has This Been Tested?

- Verified the documented script, image, and container names against `docker-compose.yml`, `run-compose.sh`, and `docker-in.sh`
- Confirmed the `secret.txt` usage matches how `scripts/create-user.sh` reads `/run/secrets/user_password`

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [x] Updated documentation if needed
- [ ] Linter and tests pass locally