### PR TITLE
feat: update CalculiX to 2.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project provides Docker Compose configuration to run CalculiX in a containerized environment.
 
-CalculiX is an open-source program for Finite Element Analysis (FEA) of structural problems. This project builds and runs CalculiX 2.20 inside an Ubuntu 22.04 container, so you can use it without installing the toolchain on your host machine.
+CalculiX is an open-source program for Finite Element Analysis (FEA) of structural problems. This project builds and runs CalculiX 2.23 inside an Ubuntu 26.04 container, so you can use it without installing the toolchain on your host machine.
 
 ## 📦 Requirements
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   ubuntu:
     container_name: ubuntu-calculix
     build: ubuntu-calculix
-    user: root
+    user: ubuntu
     working_dir: /home/ubuntu
     command: /bin/bash
     tty: true

--- a/ubuntu-calculix/Dockerfile
+++ b/ubuntu-calculix/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:22.04
+FROM ubuntu:26.04
+ARG CALCULIX_VERSION=2.23
 
 # Install dependencies
 RUN apt-get update -y && apt-get upgrade -y && \
@@ -7,6 +8,10 @@ RUN apt-get install -y neovim
 RUN apt-get install -y python3 python3-pip && \
     apt-get install -y build-essential gcc g++ gfortran make
 
-RUN adduser ubuntu
+# RUN adduser ubuntu
 COPY ./scripts/setup-calculix.sh /opt/setup-calculix.sh
-RUN bash /opt/setup-calculix.sh 
+RUN bash /opt/setup-calculix.sh $CALCULIX_VERSION
+
+USER ubuntu
+RUN echo "PATH=/opt/CalculiX/bin:$PATH" >> $HOME/.bashrc
+CMD ["/bin/bash"]

--- a/ubuntu-calculix/scripts/setup-calculix.sh
+++ b/ubuntu-calculix/scripts/setup-calculix.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
+set -e
 
-cd $(HOME)
+CALCULIX_VERSION="${1:?Usage: setup-calculix.sh <calculix-version>}"
+
+cd "$HOME"
 mkdir build-calculix
 cd build-calculix
 
@@ -11,7 +14,7 @@ curl -OL https://netlib.org/linalg/spooles/spooles.2.2.tgz
 tar -xzf spooles.2.2.tgz
 
 sed -i "s/  CC = \/usr\/lang-4.0\/bin\/cc/  CC = gcc/" Make.inc
-sed -i "s/  OPTLEVEL = -O/  OPTLEVEL = -O2/" Make.inc
+sed -i "s/  OPTLEVEL = -O/  OPTLEVEL = -O2 -fcommon -Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=return-mismatch -Wno-error=int-conversion -Wno-error=incompatible-pointer-types/" Make.inc
 make lib
 cd ../
 
@@ -31,23 +34,28 @@ make lib
 cd ../
 
 # Build CalculiX --------------------------------------------------------------
-curl -OL http://www.dhondt.de/ccx_2.20.src.tar.bz2
-curl -OL http://www.dhondt.de/ccx_2.20.test.tar.bz2
-curl -OL http://www.dhondt.de/ccx_2.20.doc.tar.bz2
-tar -xf ccx_2.20.src.tar.bz2
-tar -xf ccx_2.20.test.tar.bz2
-tar -xf ccx_2.20.doc.tar.bz2
-cd CalculiX/ccx_2.20/src
+curl -OL http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2
+curl -OL http://www.dhondt.de/ccx_${CALCULIX_VERSION}.test.tar.bz2
+curl -OL http://www.dhondt.de/ccx_${CALCULIX_VERSION}.doc.tar.bz2
+tar -xf ccx_${CALCULIX_VERSION}.src.tar.bz2
+tar -xf ccx_${CALCULIX_VERSION}.test.tar.bz2
+tar -xf ccx_${CALCULIX_VERSION}.doc.tar.bz2
+cd CalculiX/ccx_${CALCULIX_VERSION}/src
 
-sed -i "s/@ARGV=\"ccx_2.20step.c\";/@ARGV=\"CalculiXstep.c\";/" date.pl
+sed -i "s/@ARGV=\"ccx_${CALCULIX_VERSION}step.c\";/@ARGV=\"CalculiXstep.c\";/" date.pl
 sed -i "s/FFLAGS = -Wall -O2/FFLAGS = -Wall -O2 -fallow-argument-mismatch/" Makefile
+sed -i "s/CFLAGS = -Wall -O2/CFLAGS = -Wall -O2 -fcommon -Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=return-mismatch -Wno-error=int-conversion -Wno-error=incompatible-pointer-types /" Makefile
 sed -i "s/..\/..\/..\/ARPACK\/libarpack_INTEL.a /..\/..\/..\/ARPACK\/libarpack_Linux.a /" Makefile
 make
+if [ ! -x "ccx_${CALCULIX_VERSION}" ]; then
+    echo "ERROR: CalculiX build failed: 'ccx_${CALCULIX_VERSION}' was not produced" >&2
+    exit 1
+fi
 mkdir -p /opt/CalculiX
-mkdir /opt/CalculiX/bin
+mkdir -p /opt/CalculiX/bin
 cd ../../..
-cp -R CalculiX/ccx_2.20/src/ccx_2.20 /opt/CalculiX/bin/ccx
-cp -R CalculiX/ccx_2.20/test /opt/CalculiX/test
-cp -R CalculiX/ccx_2.20/doc /opt/CalculiX/doc
+cp -R CalculiX/ccx_${CALCULIX_VERSION}/src/ccx_${CALCULIX_VERSION} /opt/CalculiX/bin/ccx
+cp -R CalculiX/ccx_${CALCULIX_VERSION}/test /opt/CalculiX/test
+cp -R CalculiX/ccx_${CALCULIX_VERSION}/doc /opt/CalculiX/doc
 cd ../
 rm -rf build-calculix


### PR DESCRIPTION
## Summary

Update the Docker image to build and run CalculiX 2.23.

- Bump base image to `ubuntu:26.04` and add `ARG CALCULIX_VERSION=2.23`, passed into the setup script
- Parameterize `setup-calculix.sh` by `CALCULIX_VERSION` instead of hardcoding 2.20
- Add GCC 14+ compatibility flags (`-fcommon`, `-Wno-error=implicit-function-declaration`, `-Wno-error=implicit-int`, `-Wno-error=return-mismatch`, `-Wno-error=int-conversion`, `-Wno-error=incompatible-pointer-types`) to the SPOOLES and CalculiX builds, since the newer toolchain promotes these to hard errors
- Fail the build (`set -e` + explicit binary check) if `ccx` is not produced, and require the version argument
- Fix `cd $(HOME)` -> `cd "$HOME"`
- Run the container as the `ubuntu` user and add CalculiX to its PATH
- Update README version references to CalculiX 2.23 / Ubuntu 26.04

## Related Issues

Closes #3

## How Has This Been Tested?

- Built the image end to end; the build now stops on compile failures instead of producing a broken image
- Ran a bundled example inside the container (`ccx beamp`), which completed with "Job finished" using the SPOOLES solver
- Verified `ccx -v` reports version 2.23

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [x] Updated documentation if needed
- [x] Linter and tests pass locally